### PR TITLE
Dependabot: explicitly ignore caffeine 3.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 200
+    ignore:
+      - dependency-name: "caffeine"
+        verions: ["3.x"]


### PR DESCRIPTION
Signed-off-by: Hiroshi Miura <miurahr@linux.com>