### PR TITLE
Fix typo of public method name

### DIFF
--- a/src/main/java/io/github/eb4j/mdict/MDictDictionary.java
+++ b/src/main/java/io/github/eb4j/mdict/MDictDictionary.java
@@ -1,6 +1,6 @@
 /*
  * MD4J, a parser library for MDict format.
- * Copyright (C) 2021 Hiroshi Miura.
+ * Copyright (C) 2021,2022 Hiroshi Miura.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -34,10 +34,8 @@ import java.nio.file.Files;
 import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.DataFormatException;
 
@@ -253,7 +251,7 @@ public class MDictDictionary {
         return f;
     }
 
-    public static MDictDictionary loadDicitonary(final String mdxFile) throws MDException {
+    public static MDictDictionary loadDictionary(final String mdxFile) throws MDException {
         File file = new File(mdxFile);
         if (!file.isFile()) {
             throw new MDException("Target file is not MDict file.");

--- a/src/test/java/io/github/eb4j/mdict/MDictDictionaryTest.java
+++ b/src/test/java/io/github/eb4j/mdict/MDictDictionaryTest.java
@@ -1,6 +1,6 @@
 /*
  * MD4J, a parser library for MDict format.
- * Copyright (C) 2021 Hiroshi Miura.
+ * Copyright (C) 2021,2022 Hiroshi Miura.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,7 +22,6 @@ import org.jsoup.Jsoup;
 import org.jsoup.safety.Safelist;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -37,7 +36,7 @@ class MDictDictionaryTest {
 
     @Test
     void loadV2Dictionary() throws URISyntaxException, MDException {
-        MDictDictionary dictionary = MDictDictionary.loadDicitonary(
+        MDictDictionary dictionary = MDictDictionary.loadDictionary(
                 Objects.requireNonNull(this.getClass().getResource("/test.mdx")).toURI().getPath());
         assertNotNull(dictionary);
         assertEquals(StandardCharsets.UTF_8, dictionary.getEncoding());
@@ -59,7 +58,7 @@ class MDictDictionaryTest {
 
     @Test
     void loadV1Dictionary() throws URISyntaxException, MDException {
-        MDictDictionary dictionary = MDictDictionary.loadDicitonary(
+        MDictDictionary dictionary = MDictDictionary.loadDictionary(
                 Objects.requireNonNull(this.getClass().getResource("/wordnet.mdx")).toURI().getPath());
         assertNotNull(dictionary);
         assertEquals("1.2", dictionary.getMdxVersion());
@@ -81,12 +80,12 @@ class MDictDictionaryTest {
     }
 
     @Test
-    void loadMultipleDictionary() throws URISyntaxException, MDException, IOException {
+    void loadMultipleDictionary() throws URISyntaxException, MDException {
         String[] words = new String[] {"test", "word"};
         List<MDictDictionary> dictionaries = new ArrayList<>();
-        dictionaries.add(MDictDictionary.loadDicitonary(
+        dictionaries.add(MDictDictionary.loadDictionary(
                 Objects.requireNonNull(this.getClass().getResource("/test.mdx")).toURI().getPath()));
-        dictionaries.add(MDictDictionary.loadDicitonary(
+        dictionaries.add(MDictDictionary.loadDictionary(
                 Objects.requireNonNull(this.getClass().getResource("/wordnet.mdx")).toURI().getPath()));
         for (String word: words) {
             for (MDictDictionary dict : dictionaries) {

--- a/src/test/java/io/github/eb4j/mdict/MDictProprietaryTest.java
+++ b/src/test/java/io/github/eb4j/mdict/MDictProprietaryTest.java
@@ -41,7 +41,7 @@ class MDictProprietaryTest {
     @EnabledIf("targetFileExist")
     // Test with proprietary dictionary data; requires dictionary prepared by tester
     void loadProprietaryDictionary() throws URISyntaxException, MDException, IOException {
-        MDictDictionary dictionary = MDictDictionary.loadDicitonary(Objects.requireNonNull(
+        MDictDictionary dictionary = MDictDictionary.loadDictionary(Objects.requireNonNull(
                 this.getClass().getResource(TARGET)).toURI().getPath());
         assertTrue(dictionary.isMdx());
         assertEquals(StandardCharsets.UTF_8, dictionary.getEncoding());
@@ -78,7 +78,7 @@ class MDictProprietaryTest {
     @Test
     @EnabledIf("target2FileExist")
     void loadItalianDictionary() throws URISyntaxException, MDException {
-        MDictDictionary dictionary = MDictDictionary.loadDicitonary(Objects.requireNonNull(
+        MDictDictionary dictionary = MDictDictionary.loadDictionary(Objects.requireNonNull(
                 this.getClass().getResource(TARGET)).toURI().getPath());
         assertTrue(dictionary.isMdx());
         assertEquals(StandardCharsets.UTF_8, dictionary.getEncoding());


### PR DESCRIPTION
Change to MDictDictionary, from MDictDicitonary

Signed-off-by: Hiroshi Miura <miurahr@linux.com>